### PR TITLE
Remove encrypt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": ">=5.6.4",
         "jenssegers/mongodb": "*",
-        "illuminate/cache": "~5.0"
+        "illuminate/cache": "~5.5"
     },
     "license": "MIT",
     "authors": [

--- a/src/MongoCacheManager.php
+++ b/src/MongoCacheManager.php
@@ -20,7 +20,7 @@ class MongoCacheManager extends CacheManager
 
         return $this->repository(
             new MongoStore(
-                $connection, $this->app['encrypter'], $config['table'], $this->getPrefix($config)
+                $connection, $config['table'], $this->getPrefix($config)
             )
         );
     }

--- a/src/MongoStore.php
+++ b/src/MongoStore.php
@@ -29,7 +29,7 @@ class MongoStore extends DatabaseStore
             $cache = (object) $cache;
         }
 
-        $current = $this->encrypter->decrypt($cache->value);
+        $current = $cache->value;
         $new = $callback((int) $current, $value);
 
         if (! is_numeric($current)) {

--- a/src/MongoStore.php
+++ b/src/MongoStore.php
@@ -29,7 +29,7 @@ class MongoStore extends DatabaseStore
             $cache = (object) $cache;
         }
 
-        $current = $cache->value;
+        $current = unserialize($cache->value);
         $new = $callback((int) $current, $value);
 
         if (! is_numeric($current)) {
@@ -37,7 +37,7 @@ class MongoStore extends DatabaseStore
         }
 
         $this->table()->where('key', $prefixed)->update([
-            'value' => $this->encrypter->encrypt($new)
+            'value' => serialize($new)
         ]);
 
         return $new;


### PR DESCRIPTION
From Laravel 5.5, `DatabaseStore`'s constructer has been changed, `encrypter`  is removed. 

This PR provides updates to make this library compatible with Laravel 5.5 !